### PR TITLE
standard.js missing from deps. lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "babel-loader": "^6.2.4",
     "express": "^4.14.0",
     "webpack": "^2.0.0-beta",
-    "json-loader": "^0.5.4"
+    "json-loader": "^0.5.4",
+    "standard": "*"
   },
   "repository": {
     "type": "git",

--- a/src/sample-app.js
+++ b/src/sample-app.js
@@ -43,9 +43,9 @@ $('#login').click(function () {
     if (abcWallet == null) {
       // Create an ethereum wallet if one doesn't exist:
       const keys = {
-        ethereumKey: new Buffer(secureRandom(32)).toString('hex')
+        ethereumKey: Buffer.alloc(secureRandom(32)).toString('hex')
       }
-      account.createWallet(walletType, keys, function (err, id) {
+      account.createWallet(walletType, keys, function (error, id) {
         if (error) {
           console.log(error)
         } else {


### PR DESCRIPTION
Hi,
I've been looking through the core-js code and found that the "npm run lint" wasn't working because "standard" wasn't in the dependencies, so I added that.
When standard lint ran it picked up a couple of errors so I fixed those too.

>   /home/bitnami/projects/airbitz-core-js-sample/src/sample-app.js:46:22: 'new Buffer()' was deprecated since v6. Use 'Buffer.alloc()' or 'Buffer.from()' (use 'https://www.npmjs.com/package/safe-buffer' for '<4.5.0') instead.
>  /home/bitnami/projects/airbitz-core-js-sample/src/sample-app.js:48:46: Expected error to be handled.

One was a deprecation, another was an actual error caused by a misnamed var.

Jason
